### PR TITLE
Set image dimension ordering convention to 'th'

### DIFF
--- a/Network.py
+++ b/Network.py
@@ -10,7 +10,7 @@ import h5py
 from keras.models import Sequential
 from keras.layers.convolutional import Convolution2D, ZeroPadding2D, AveragePooling2D
 from keras import backend as K
-
+K.set_image_dim_ordering('th')
 
 #### There are 3 Parts #####
 


### PR DESCRIPTION
The code and the provided "vgg16_weights.h5" file follow Theano conventions for dimension ordering. Due to recent updates in the libraries, this won't work. Using a Theano backend in its entirety also won't work without modifying the rest of the code. This is perhaps the quickest way to solve this issue.

Before I patched this in, I was getting the following error:

```
Traceback (most recent call last):
  File "network.py", line 265, in <module>
    model.add(AveragePooling2D((2, 2), strides=(2, 2)))
  File "/usr/local/lib/python2.7/site-packages/keras/models.py", line 308, in add
    output_tensor = layer(self.outputs[0])
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 514, in __call__
    self.add_inbound_node(inbound_layers, node_indices, tensor_indices)
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 572, in add_inbound_node
    Node.create_node(self, inbound_layers, node_indices, tensor_indices)
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 149, in create_node
    output_tensors = to_list(outbound_layer.call(input_tensors[0], mask=input_masks[0]))
  File "/usr/local/lib/python2.7/site-packages/keras/layers/pooling.py", line 162, in call
    dim_ordering=self.dim_ordering)
  File "/usr/local/lib/python2.7/site-packages/keras/layers/pooling.py", line 254, in _pooling_function
    border_mode, dim_ordering, pool_mode='avg')
  File "/usr/local/lib/python2.7/site-packages/keras/backend/tensorflow_backend.py", line 1703, in pool2d
    x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/nn_ops.py", line 508, in avg_pool
    name=name)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/gen_nn_ops.py", line 48, in _avg_pool
    data_format=data_format, name=name)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/op_def_library.py", line 704, in apply_op
    op_def=op_def)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 2262, in create_op
    set_shapes_for_outputs(ret)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1702, in set_shapes_for_outputs
    shapes = shape_func(op)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/common_shapes.py", line 433, in avg_pool_shape
    padding)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/common_shapes.py", line 184, in get2d_conv_output_size
    (row_stride, col_stride), padding_type)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/ops/common_shapes.py", line 149, in get_conv_output_size
    "Filter: %r Input: %r" % (filter_size, input_size))
ValueError: Filter must not be larger than the input: Filter: (2, 2) Input: (1, 256)
```
